### PR TITLE
ci(dependabot): define `.github/actions` directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/*
     schedule:
       interval: weekly
     commit-message:


### PR DESCRIPTION
Dependabot knows how to find top-level `action.yml` actions and `.github/workflows/*.yml` workflows.

But `.github/actions` is a convention that it doesn't know about.
