### PR TITLE
Curseforge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@
 
 An internal tool for publishing [Freecam] releases.
 
+Uses [CurseforgeUpload4j] to upload releases to CurseForge.
+
 [Freecam]: https://github.com/MinecraftFreecam/Freecam
+[CurseforgeUpload4j]]: https://github.com/firstdarkdev/CurseUpload4J

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
 dependencies {
     implementation(project(":core"))
     implementation(project(":cli"))
+    implementation(project(":curseforge"))
     implementation(libs.kotlin.coroutines)
     testImplementation(libs.kotlin.test)
     testImplementation(testFixtures(project(":api")))

--- a/cli/src/main/kotlin/net/xolt/freecam/publish/cli/CurseForgeOptionGroup.kt
+++ b/cli/src/main/kotlin/net/xolt/freecam/publish/cli/CurseForgeOptionGroup.kt
@@ -1,0 +1,33 @@
+package net.xolt.freecam.publish.cli
+
+import com.github.ajalt.clikt.parameters.groups.OptionGroup
+import com.github.ajalt.clikt.parameters.options.defaultLazy
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.ulong
+import net.xolt.freecam.model.ReleaseMetadata
+import net.xolt.freecam.publish.model.CurseForgeConfig
+
+internal class CurseForgeOptionGroup(
+    private val metadata: () -> ReleaseMetadata,
+) : CurseForgeConfig, OptionGroup(
+    name = "CurseForge options",
+    help = "Options for configuring CurseForge release publishing",
+) {
+    override val projectId by option("--curseforge-project-id", envvar = "CURSEFORGE_PROJECT_ID")
+        .ulong()
+        .help("CurseForge Project ID")
+        .defaultLazy(defaultForHelp = "Read from --metadata") {
+            metadata().platforms.curseforge.id
+        }
+
+    override val token by option("--curseforge-token", envvar = "CURSEFORGE_TOKEN")
+        .help("CurseForge API token")
+        .required()
+
+    override fun toString(): String {
+        val maskedToken = token.take(4).padEnd(10, '*')
+        return "CurseForgeOptionGroup(token='$maskedToken', projectId='$projectId')"
+    }
+}

--- a/cli/src/main/kotlin/net/xolt/freecam/publish/cli/PublishCliCommand.kt
+++ b/cli/src/main/kotlin/net/xolt/freecam/publish/cli/PublishCliCommand.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.decodeFromStream
 import net.xolt.freecam.model.ReleaseMetadata
 import net.xolt.freecam.publish.PublisherFactory
 import net.xolt.freecam.publish.logging.*
+import net.xolt.freecam.publish.model.CurseForgeConfig
 import java.nio.file.Path
 import kotlin.io.path.inputStream
 
@@ -40,6 +41,7 @@ internal class PublishCliCommand(
         publisherFactory(
             dryRun = dryRun,
             artifactsDir = artifactsDir,
+            curseforgeConfig = curseforge,
         )
     }
 
@@ -63,6 +65,8 @@ internal class PublishCliCommand(
 
     val dryRun: Boolean by option("--dry-run").flag()
         .help("Perform a dry run without making any actual API calls")
+
+    val curseforge: CurseForgeConfig by CurseForgeOptionGroup { metadata }
 
     private val verbosity by VerbosityOptionGroup()
     val logLevel: LogLevel get() = verbosity.level

--- a/cli/src/test/kotlin/net/xolt/freecam/publish/cli/CurseForgeOptionGroupTest.kt
+++ b/cli/src/test/kotlin/net/xolt/freecam/publish/cli/CurseForgeOptionGroupTest.kt
@@ -1,0 +1,34 @@
+package net.xolt.freecam.publish.cli
+
+import com.github.ajalt.clikt.command.test
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import net.xolt.freecam.test.MetadataFixtures.testMetadata
+import net.xolt.freecam.test.toTestFile
+import kotlin.io.path.absolutePathString
+import kotlin.test.Test
+
+class CurseForgeOptionGroupTest {
+
+    @Test
+    fun `toString masks token`() = runTest {
+        val cmd = testCommand()
+
+        cmd.test(listOf("--curseforge-token", "abcdef123456", "--curseforge-project-id", "12345"))
+
+        cmd.curseforge.toString() shouldBe "CurseForgeOptionGroup(token='abcd******', projectId='12345')"
+    }
+
+    @Test
+    fun `project id defaults to metadata`() = runTest {
+        val metadata = testMetadata(
+            curseforgeId = 123456789UL,
+        )
+
+        val cmd = testCommand()
+
+        cmd.test(listOf("--metadata", metadata.toTestFile().absolutePathString()))
+
+        cmd.curseforge.projectId shouldBe 123456789UL
+    }
+}

--- a/cli/src/test/kotlin/net/xolt/freecam/publish/cli/PublishCliCommandTest.kt
+++ b/cli/src/test/kotlin/net/xolt/freecam/publish/cli/PublishCliCommandTest.kt
@@ -55,7 +55,7 @@ class PublishCliCommandTest {
         var actualDir: Path? = null
 
         val publisher = mockk<Publisher>(relaxUnitFun = true)
-        val publisherFactory = PublisherFactory { dryRun, artifactsDir ->
+        val publisherFactory = PublisherFactory { dryRun, artifactsDir, _ ->
             dryPublisher = dryRun
             actualDir = artifactsDir
             publisher
@@ -64,6 +64,7 @@ class PublishCliCommandTest {
         val cmd = testCommand(publisherFactory = publisherFactory)
         val result = cmd.test(listOf(
             "--dry-run",
+            "--curseforge-token", "token",
             "--metadata",
             metadata.toTestFile().absolutePathString(),
             dir.absolutePathString(),
@@ -85,7 +86,7 @@ class PublishCliCommandTest {
         var actualDir: Path? = null
 
         val publisher = mockk<Publisher>(relaxUnitFun = true)
-        val publisherFactory = PublisherFactory { dryRun, artifactsDir ->
+        val publisherFactory = PublisherFactory { dryRun, artifactsDir, _ ->
             dryPublisher = dryRun
             actualDir = artifactsDir
             publisher
@@ -96,6 +97,7 @@ class PublishCliCommandTest {
 
         val cmd = testCommand(publisherFactory = publisherFactory)
         val result = cmd.test(listOf(
+            "--curseforge-token", "token",
             "--metadata",
             metadata.toTestFile().absolutePathString(),
             dir.absolutePathString(),
@@ -154,6 +156,6 @@ internal fun testCommand(
 
 internal fun mockPublisherFactory(
     relaxUnitFun: Boolean = false,
-) = PublisherFactory { _, _ ->
+) = PublisherFactory { _, _, _ ->
     mockk(relaxUnitFun = relaxUnitFun)
 }

--- a/core/src/main/kotlin/net/xolt/freecam/publish/Publisher.kt
+++ b/core/src/main/kotlin/net/xolt/freecam/publish/Publisher.kt
@@ -1,6 +1,7 @@
 package net.xolt.freecam.publish
 
 import net.xolt.freecam.model.ReleaseMetadata
+import net.xolt.freecam.publish.model.CurseForgeConfig
 import java.nio.file.Path
 
 fun interface Publisher {
@@ -12,10 +13,12 @@ fun interface PublisherFactory {
     fun create(
         dryRun: Boolean,
         artifactsDir: Path,
+        curseforgeConfig: CurseForgeConfig,
     ): Publisher
 
     operator fun invoke(
         dryRun: Boolean,
         artifactsDir: Path,
-    ) = create(dryRun, artifactsDir)
+        curseforgeConfig: CurseForgeConfig,
+    ) = create(dryRun, artifactsDir, curseforgeConfig)
 }

--- a/core/src/main/kotlin/net/xolt/freecam/publish/model/CurseForgeConfig.kt
+++ b/core/src/main/kotlin/net/xolt/freecam/publish/model/CurseForgeConfig.kt
@@ -1,0 +1,6 @@
+package net.xolt.freecam.publish.model
+
+interface CurseForgeConfig {
+    val projectId: ULong
+    val token: String
+}

--- a/curseforge/build.gradle.kts
+++ b/curseforge/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+version = property("version").toString()
+group = property("group").toString()
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(project(":core"))
+    implementation(libs.curseforge.upload)
+    implementation(libs.kotlin.coroutines)
+    testImplementation(testFixtures(project(":core")))
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotest.assertions)
+    testImplementation(libs.kotlin.coroutines.test)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeClient.kt
+++ b/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeClient.kt
@@ -1,0 +1,65 @@
+package net.xolt.freecam.publish.platforms
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import me.hypherionmc.curseupload.CurseUploadApi
+import me.hypherionmc.curseupload.constants.CurseChangelogType
+import me.hypherionmc.curseupload.constants.GameType
+import me.hypherionmc.curseupload.requests.CurseArtifact
+import net.xolt.freecam.model.Relationship
+import net.xolt.freecam.publish.logging.Logger
+import net.xolt.freecam.publish.logging.slf4j
+import net.xolt.freecam.publish.model.CurseForgeConfig
+import net.xolt.freecam.publish.model.ReleaseArtifact
+import java.io.File
+
+internal class CurseForgeClient(
+    private val projectId: Long,
+    private val api: CurseUploadApi,
+    private val logger: Logger,
+) {
+
+    constructor(
+        dryRun: Boolean,
+        config: CurseForgeConfig,
+        logger: Logger,
+    ) : this(
+        projectId = config.projectId.toLong(),
+        api = CurseUploadApi(config.token, logger.slf4j).apply {
+            // Instructs api.upload() to print instead of upload
+            isDebug = dryRun
+            gameType = GameType.MINECRAFT
+        },
+        logger,
+    )
+
+     suspend fun uploadFile(spec: ReleaseArtifact) = uploadFile(spec.artifact.toFile()) {
+         displayName(spec.displayName)
+         releaseType(spec.versionType.toCurseForge())
+
+         spec.changelog.takeIf { it.isNotBlank() }?.let {
+             changelog(it)
+             changelogType(CurseChangelogType.MARKDOWN)
+         }
+
+         sequenceOf(
+             spec.loaders,
+             spec.curseForgeEnvironments,
+             spec.curseForgeJavaVersions,
+             spec.curseForgeMinecraftVersions,
+         ).flatten().forEach(::addGameVersion)
+
+         spec.relationships.forEach { (slug, _, type) ->
+             when (type) {
+                 Relationship.Type.REQUIRED -> requirement(slug)
+                 Relationship.Type.OPTIONAL -> optional(slug)
+                 Relationship.Type.BUNDLED -> embedded(slug)
+             }
+         }
+     }
+
+    suspend fun uploadFile(file: File, builder: CurseArtifact.() -> Unit) {
+        val artifact = CurseArtifact(file, projectId).apply(builder)
+        withContext(Dispatchers.IO) { api.upload(artifact) }
+    }
+}

--- a/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeExtensions.kt
+++ b/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeExtensions.kt
@@ -1,0 +1,43 @@
+package net.xolt.freecam.publish.platforms
+
+import me.hypherionmc.curseupload.constants.CurseReleaseType
+import net.xolt.freecam.model.ReleaseType
+import net.xolt.freecam.publish.model.ReleaseArtifact
+
+private val JAVA_VERSION_PATTERN = "^java_(\\d+)$".toRegex()
+private val LEGACY_SNAPSHOT_PATTERN = "^[A-Za-z0-9]+$".toRegex()
+private val PRE_RELEASE_PATTERN = "^(.*)-(pre|rc)-\\d+$".toRegex()
+private val SNAPSHOT_PATTERN = "^(.*)-snapshot-\\d+$".toRegex()
+
+internal fun ReleaseType.toCurseForge(): CurseReleaseType = when (this) {
+    ReleaseType.RELEASE -> CurseReleaseType.RELEASE
+    ReleaseType.RELEASE_CANDIDATE -> CurseReleaseType.BETA
+    ReleaseType.BETA -> CurseReleaseType.BETA
+    ReleaseType.ALPHA -> CurseReleaseType.ALPHA
+}
+
+internal val ReleaseArtifact.curseForgeEnvironments: List<String>
+    get() = environments.map { it.toString().lowercase() }
+
+internal val ReleaseArtifact.curseForgeJavaVersions: List<String>
+    get() = javaVersions.map {
+        val match = requireNotNull(JAVA_VERSION_PATTERN.find(it)) {
+            "Invalid Java Version: $it"
+        }
+        val version = match.groupValues[1].toUInt()
+        "Java $version"
+    }
+
+internal val ReleaseArtifact.curseForgeMinecraftVersions: List<String>
+    get() = gameVersions
+        .filter { version ->
+            sequenceOf(
+                LEGACY_SNAPSHOT_PATTERN,
+                PRE_RELEASE_PATTERN,
+            ).none(version::matches)
+        }
+        .map { version ->
+            SNAPSHOT_PATTERN.find(version)
+                ?.let { "${it.groupValues[1]}-snapshot" }
+                ?: version
+        }

--- a/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgePlatform.kt
+++ b/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgePlatform.kt
@@ -1,0 +1,39 @@
+package net.xolt.freecam.publish.platforms
+
+import net.xolt.freecam.model.ReleaseMetadata
+import net.xolt.freecam.publish.logging.Logger
+import net.xolt.freecam.publish.model.CurseForgeConfig
+import net.xolt.freecam.publish.model.ReleaseArtifact
+
+interface CurseForgePlatform : Platform { companion object }
+
+fun CurseForgePlatform.Companion.create(
+    dryRun: Boolean = false,
+    config: CurseForgeConfig,
+): CurseForgePlatform = DefaultCurseForgePlatform(
+    dryRun = dryRun,
+    config = config,
+)
+
+private fun createLogger(dryRun: Boolean) = Logger.default
+    .let { if (dryRun) it.scoped("dry-run") else it }
+    .scoped("CurseForge")
+
+internal class DefaultCurseForgePlatform(
+    dryRun: Boolean,
+    private val config: CurseForgeConfig,
+    private val logger: Logger = createLogger(dryRun),
+    private val client: CurseForgeClient = CurseForgeClient(
+        dryRun = dryRun,
+        config = config,
+        logger = logger,
+    ),
+) : CurseForgePlatform {
+
+    override suspend fun publishRelease(metadata: ReleaseMetadata, artifacts: List<ReleaseArtifact>) {
+        artifacts.forEach { spec ->
+            logger.info { "publishing artifact ${spec.name}" }
+            client.uploadFile(spec)
+        }
+    }
+}

--- a/curseforge/src/test/kotlin/net/xolt/freecam/publish/platforms/CurseForgeExtensionsTest.kt
+++ b/curseforge/src/test/kotlin/net/xolt/freecam/publish/platforms/CurseForgeExtensionsTest.kt
@@ -1,0 +1,60 @@
+package net.xolt.freecam.publish.platforms
+
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.collections.shouldContainExactly
+import net.xolt.freecam.model.Environment
+import net.xolt.freecam.test.ReleaseArtifactFixtures.testArtifact
+import kotlin.test.Test
+
+class CurseForgeExtensionsTest {
+
+    @Test
+    fun `maps valid java versions`() {
+        val artifact = testArtifact(javaVersions = setOf("java_8", "java_17"))
+
+        artifact.curseForgeJavaVersions shouldContainExactly listOf(
+            "Java 8",
+            "Java 17",
+        )
+    }
+
+    @Test
+    fun `fails on invalid java version`() {
+        val artifact = testArtifact(javaVersions = setOf("java8"))
+
+        shouldThrowExactly<IllegalArgumentException> {
+            artifact.curseForgeJavaVersions
+        }
+    }
+
+    @Test
+    fun `filters legacy and pre-release versions`() {
+        val artifact = testArtifact(gameVersions = setOf(
+            "1.20.1",
+            "1.21-pre-1",
+            "23w13a",           // legacy snapshot
+        ))
+
+        artifact.curseForgeMinecraftVersions shouldContainExactly listOf(
+            "1.20.1",
+        )
+    }
+
+    @Test
+    fun `normalizes snapshot versions`() {
+        val artifact = testArtifact(gameVersions = setOf(
+            "1.21-snapshot-5",
+        ))
+
+        artifact.curseForgeMinecraftVersions shouldContainExactly listOf(
+            "1.21-snapshot",
+        )
+    }
+
+    @Test
+    fun `maps environments to lowercase`() {
+        val artifact = testArtifact(environments = setOf(Environment.CLIENT, Environment.SERVER))
+
+        artifact.curseForgeEnvironments shouldContainExactly listOf("client", "server")
+    }
+}

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -7,6 +7,7 @@ coroutines = "1.10.2"
 clikt = "5.1.0"
 kotest = "6.1.2"
 mockk = "1.14.9"
+curse4j = "1.0.13"
 
 [libraries]
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
@@ -18,6 +19,7 @@ clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotest-assertions = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+curseforge-upload = { group = "me.hypherionmc.modutils", name = "CurseUpload4j", version.ref = "curse4j" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,14 @@ dependencyResolutionManagement {
         }
     }
     repositories {
+        exclusiveContent {
+            forRepository {
+                maven("https://maven.firstdark.dev/releases") { name = "First Dark Development" }
+            }
+            filter {
+                includeGroupAndSubgroups("me.hypherionmc")
+            }
+        }
         gradlePluginPortal()
         mavenCentral()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "api",
     "core",
     "cli",
+    "curseforge"
 )
 
 rootProject.name = "freecam-publish"

--- a/src/main/kotlin/net/xolt/freecam/publish/DefaultPublisher.kt
+++ b/src/main/kotlin/net/xolt/freecam/publish/DefaultPublisher.kt
@@ -3,24 +3,29 @@ package net.xolt.freecam.publish
 import net.xolt.freecam.model.ReleaseMetadata
 import net.xolt.freecam.publish.model.ReleaseArtifact
 import net.xolt.freecam.publish.model.resolveArtifacts
+import net.xolt.freecam.publish.platforms.CurseForgePlatform
+import net.xolt.freecam.publish.platforms.create
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.pathString
 
-val DefaultPublisherFactory = PublisherFactory { dryRun, artifactsDir ->
+val DefaultPublisherFactory = PublisherFactory { dryRun, artifactsDir, curseforgeConfig ->
     DefaultPublisher(
         artifactsDir = artifactsDir,
+        curseforge = CurseForgePlatform.create(dryRun, curseforgeConfig),
     )
 }
 
 data class DefaultPublisher(
     val artifactsDir: Path,
+    val curseforge: CurseForgePlatform,
 ) : Publisher {
 
     override suspend fun publish(metadata: ReleaseMetadata) {
         val artifacts = metadata.resolveArtifacts(artifactsDir).apply {
             verifyExists()
         }
+        curseforge.publishRelease(metadata, artifacts)
     }
 
     private fun List<ReleaseArtifact>.verifyExists() {

--- a/src/test/kotlin/net/xolt/freecam/publish/DefaultPublisherTest.kt
+++ b/src/test/kotlin/net/xolt/freecam/publish/DefaultPublisherTest.kt
@@ -3,7 +3,12 @@ package net.xolt.freecam.publish
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.matchers.string.shouldContainOnlyOnce
+import io.mockk.MockKMatcherScope
+import io.mockk.coVerify
+import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import net.xolt.freecam.publish.model.ReleaseArtifact
+import net.xolt.freecam.publish.platforms.CurseForgePlatform
 import net.xolt.freecam.test.MetadataFixtures.testMetadata
 import net.xolt.freecam.test.MetadataFixtures.testProjectMetadata
 import net.xolt.freecam.test.createTestDir
@@ -20,22 +25,30 @@ class DefaultPublisherTest {
 
     @Test
     fun `publisher calls each platform with all artifacts`() = runTest {
+        val curseforge = mockk<CurseForgePlatform>(relaxUnitFun = true)
+
         val dir = createTestDir()
         val metadata = testMetadata(versions = testVersions)
         val metadataArtifacts = metadata.versions.map {
             dir.resolve(it.filename).apply(Path::createFile)
         }
 
-        DefaultPublisher(dir).publish(metadata)
+        DefaultPublisher(dir, curseforge).publish(metadata)
 
-        // TODO: verify
+        fun MockKMatcherScope.verifyArtifacts() = match<List<ReleaseArtifact>> { artifacts ->
+            artifacts.map { it.artifact } == metadataArtifacts
+        }
+
+        coVerify { curseforge.publishRelease(metadata, verifyArtifacts()) }
     }
 
     @Test
     fun `fails if artifact missing`(): Unit = runTest {
+        val curseforge = mockk<CurseForgePlatform>(relaxUnitFun = true)
+
         val dir = createTestDir()
         val metadata = testMetadata(versions = testVersions)
-        val publisher = DefaultPublisher(dir)
+        val publisher = DefaultPublisher(dir, curseforge)
 
         val ex = shouldThrowExactly<IllegalArgumentException> {
             publisher.publish(metadata)


### PR DESCRIPTION
Adds CurseForge publishing support, using [CurseUpload4J](https://github.com/firstdarkdev/CurseUpload4J) (from [ModPublisher](https://github.com/firstdarkdev/modpublisher)).