### PR TITLE
feat(setup-publish): init GitHub Action

### DIFF
--- a/.github/workflows/test-actions.yaml
+++ b/.github/workflows/test-actions.yaml
@@ -1,0 +1,119 @@
+name: Action
+
+on:
+  pull_request:
+    paths:
+      - action.yaml
+      - gradle.properties
+
+# Group workflow runs by ref.
+# New runs cancel any in progress.
+concurrency:
+  group: test-actions-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-setup-action:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-slim
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v6
+        with:
+          path: setup-publisher
+          sparse-checkout: |
+            action.yaml
+            gradle.properties
+          sparse-checkout-cone-mode: false
+
+      - name: Run setup-publisher
+        id: setup
+        uses: ./setup-publisher
+
+      - name: Check outputs
+        env:
+          exe_path: ${{ steps.setup.outputs.path }}
+          version: ${{ steps.setup.outputs.version }}
+        run: |
+          echo "::notice::version: $version"
+          echo "::notice::exe: $exe_path"
+
+      - name: Check installed (powershell)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          expected: ${{ steps.setup.outputs.path }}
+        run: |
+          $actual = Get-Command freecam-publish.bat -CommandType Application -ErrorAction SilentlyContinue
+          if ($null -eq $actual) {
+            Write-Error "Expected freecam-publish.bat to be in PATH, but it was not found"
+            exit 1
+          }
+
+          if ($actual.Source -ne $env:expected) {
+            Write-Error "Expected ${env:expected} to be in PATH, but got $($actual.Source)"
+            exit 1
+          }
+
+      - name: Check installed (bash)
+        if: runner.os != 'Windows'
+        env:
+          expected: ${{ steps.setup.outputs.path }}
+        run: |
+          actual=$(command -v freecam-publish)
+          [ "$actual" = "$expected" ] || {
+            echo "::error::Expected $expected to be in PATH, but got $actual"
+            exit 1
+          }
+
+      - name: Install Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+
+      - name: Check version (powershell)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          version: ${{ steps.setup.outputs.version }}
+        run: |
+          $output = & freecam-publish --version
+          if ($output -like "*${env:version}*") {
+            Write-Host "Successfully managed to find '${env:version}' in the --version output"
+          } else {
+            Write-Error "Could not find '${env:version}' in the --version output. Output was: $output"
+            exit 1
+          }
+
+      - name: Check version (bash)
+        env:
+          version: ${{ steps.setup.outputs.version }}
+        run: |
+          output=$(freecam-publish --version)
+          if [[ "$output" = *"$version"* ]]; then
+            echo "Successfully managed to find '$version' in the --version output"
+          else
+            echo "::error::Could not find '$version' in the --version output" >&2
+            echo "$output" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ dependencies {
 
 You can pin a specific version by replacing `-SNAPSHOT` with a git tag or commit, see [JitPack].
 
+### Setup Action
+
+A GitHub Action is available to install the Publisher CLI.
+It installs the CLI from the corresponding release assets.
+See [`action.yaml`](./action.yaml) for details.
+
 [Freecam]: https://github.com/MinecraftFreecam/Freecam
 [CurseUpload4J]: https://github.com/firstdarkdev/CurseUpload4J
 [Modrinth4J]: https://github.com/masecla22/Modrinth4J

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,211 @@
+name: setup-publisher
+description: Install Freecam Publisher
+
+inputs:
+  install_to_path:
+    description: Add the executables to the PATH
+    required: true
+    default: 'true'
+  github_token:
+    description: GitHub token (defaults to GITHUB_TOKEN)
+    required: false
+
+outputs:
+  version:
+    description: The version that was installed
+    value: ${{ steps.version.outputs.version }}
+  path:
+    description: Path to the Publisher executable
+    value: ${{ steps.resolve.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create working directory
+      shell: python
+      run: |
+        from tempfile import mkdtemp
+        from os import environ
+
+        with open(environ["GITHUB_ENV"], "a") as env:
+            print(f"WORK_DIR={mkdtemp()}", file=env)
+
+    - name: Read version from gradle.properties
+      id: version
+      shell: python
+      run: |
+        import os
+        from pathlib import Path
+
+        def find_file() -> Path:
+            action_path = os.environ.get("GITHUB_ACTION_PATH")
+            if action_path:
+                p = Path(action_path) / "gradle.properties"
+                if p.is_file():
+                    return p
+
+            p = Path("gradle.properties")
+            if p.is_file():
+                return p
+
+            raise SystemExit("::error::gradle.properties not found")
+
+        def read_version(path: Path) -> str:
+            with path.open() as f:
+                for raw in f:
+                    line = raw.strip()
+                    if not line or line.startswith(("#", "!")):
+                        continue
+
+                    key, sep, value = line.partition("=")
+                    if sep and key.strip() == "version":
+                        return value.lstrip(" ")
+
+            raise SystemExit(f"::error::Failed to parse version")
+
+        file = find_file()
+        version = read_version(file)
+
+        with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+            print(f"version={version}", file=out)
+
+        with open(os.environ["GITHUB_ENV"], "a") as env:
+            print(f"PUBLISHER_VERSION={version}", file=env)
+
+    - name: Download release asset
+      id: asset
+      uses: actions/github-script@v9
+      with:
+        github-token: ${{ inputs.github_token || github.token }}
+        script: |
+          const fs = require("fs")
+          const path = require("path")
+          const { pipeline } = require("stream/promises")
+          const { Readable } = require("stream")
+
+          const version = process.env.PUBLISHER_VERSION
+          const workDir = process.env.WORK_DIR
+          const expectedName = `freecam-publish-${version}.tar.gz`
+
+          const { owner, repo } = context.repo
+
+          const release = await github.rest.repos.getReleaseByTag({
+            owner,
+            repo,
+            tag: `v${version}`,
+          })
+
+          const asset = release.data.assets.find(a => a.name === expectedName)
+          if (!asset) {
+            core.setFailed(`Asset not found: ${expectedName}`)
+            return
+          }
+
+          const archivePath = path.join(workDir, asset.name)
+
+          core.info(`Downloading ${asset.name} → ${archivePath}`)
+          const { data: stream } = await github.request({
+            method: "GET",
+            url: asset.url,
+            headers: { accept: "application/octet-stream" },
+            request: { parseSuccessResponseBody: false },
+          })
+
+          await pipeline(Readable.fromWeb(stream), fs.createWriteStream(archivePath))
+
+          core.exportVariable("ARCHIVE_NAME", asset.name)
+          core.exportVariable("ARCHIVE_PATH", archivePath)
+          core.setOutput("size", asset.size)
+          if (asset.digest) core.setOutput("digest", asset.digest)
+
+    - name: Verify size
+      shell: python
+      env:
+        size: ${{ steps.asset.outputs.size }}
+      run: |
+        import os
+
+        name = os.environ["ARCHIVE_NAME"]
+        expected = int(os.environ["size"])
+        actual = os.path.getsize(os.environ["ARCHIVE_PATH"])
+
+        if actual != expected:
+          raise SystemExit(
+              f"::error::Size mismatch for {name}"
+              "%0A"
+              f"Expected: {expected}"
+              "%0A"
+              f"Actual:   {actual}"
+          )
+
+    - name: Verify checksum
+      if: startsWith(steps.asset.outputs.digest, 'sha256:')
+      shell: python
+      env:
+        digest: ${{ steps.asset.outputs.digest }}
+      run: |
+        from hashlib import sha256
+        from os import environ
+        from pathlib import Path
+
+        name = environ["ARCHIVE_NAME"]
+        expected = environ["digest"].removeprefix("sha256:")
+
+        digest = sha256()
+        with open(environ["ARCHIVE_PATH"], "rb") as f:
+          for chunk in iter(lambda: f.read(8192), b""):
+            digest.update(chunk)
+
+        actual = digest.hexdigest()
+
+        if actual != expected:
+          raise SystemExit(
+              f"::error::SHA-256 hash mismatch for {name}"
+              "%0A"
+              f"Expected: {expected}"
+              "%0A"
+              f"Actual:   {actual}"
+          )
+
+    - name: Extract archive
+      shell: python
+      run: |
+        import tarfile
+        from os import environ
+
+        with tarfile.open(environ["ARCHIVE_PATH"], "r:gz") as tar:
+            tar.extractall(environ["WORK_DIR"], filter="tar")
+
+    - name: Resolve executable path
+      id: resolve
+      shell: python
+      run: |
+        import os
+        from pathlib import Path
+
+        version = os.environ["PUBLISHER_VERSION"]
+        root = Path(os.environ["WORK_DIR"]) / f"freecam-publish-{version}"
+
+        if os.environ["RUNNER_OS"] == "Windows":
+            exe = root / "bin" / "freecam-publish.bat"
+        else:
+            exe = root / "bin" / "freecam-publish"
+
+        if not exe.is_file():
+            raise SystemExit(f"::error::Executable not found at {exe}")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+            print(f"path={exe.resolve()}", file=out)
+
+    - name: Install to PATH
+      if: inputs.install_to_path == 'true'
+      shell: python
+      env:
+        EXE_PATH: ${{ steps.resolve.outputs.path }}
+      run: |
+        from os import environ
+        from pathlib import Path
+
+        exe = Path(environ["EXE_PATH"])
+        with open(environ["GITHUB_PATH"], "a") as gh_path:
+          print(exe.parent, file=gh_path)


### PR DESCRIPTION
Adds a `setup-publisher` action that installs the "current" version from its GitHub Release assets.

This allows Freecam to depend on a semver major version of `uses: MinecraftFreecam/Publisher@v1` and automatically install the latest `v1.x.x` release.

TODO:

- [x] checkout & self-test workflow
- [x] document in README
- [ ] test on a fork?
