### PR TITLE
feat(curseforge): retry if invalid versions are snapshots

### DIFF
--- a/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeClient.kt
+++ b/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeClient.kt
@@ -32,7 +32,10 @@ internal class CurseForgeClient(
         logger,
     )
 
-     suspend fun uploadFile(spec: ReleaseArtifact) = uploadFile(spec.artifact.toFile()) {
+     suspend fun uploadFile(
+         spec: ReleaseArtifact,
+         excludeVersions: Set<String> = emptySet(),
+     ) = uploadFile(spec.artifact.toFile()) {
          displayName(spec.displayName)
          releaseType(spec.versionType.toCurseForge())
 
@@ -45,7 +48,7 @@ internal class CurseForgeClient(
              spec.loaders,
              spec.curseForgeEnvironments,
              spec.curseForgeJavaVersions,
-             spec.curseForgeMinecraftVersions,
+             spec.curseForgeMinecraftVersions.filterNot(excludeVersions::contains),
          ).flatten().forEach(::addGameVersion)
 
          spec.relationships.forEach { (slug, _, type) ->

--- a/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeExtensions.kt
+++ b/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgeExtensions.kt
@@ -1,6 +1,7 @@
 package net.xolt.freecam.publish.platforms
 
 import me.hypherionmc.curseupload.constants.CurseReleaseType
+import me.hypherionmc.curseupload.errors.InvalidCurseVersionException
 import net.xolt.freecam.model.ReleaseType
 import net.xolt.freecam.publish.logging.Logger
 import net.xolt.freecam.publish.model.ReleaseArtifact
@@ -44,3 +45,12 @@ internal val ReleaseArtifact.curseForgeMinecraftVersions: List<String>
                 ?.let { "${it.groupValues[1]}-snapshot" }
                 ?: version
         }
+
+/**
+ * True when all [invalidVersions][InvalidCurseVersionException.invalidVersions]
+ * are snapshot versions.
+ *
+ * Note: curseforge snapshot versions are suffixed with `"-snapshot"`.
+ */
+internal val InvalidCurseVersionException.isSnapshotOnly
+    get() = invalidVersions.all { it.endsWith("-snapshot") }

--- a/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgePlatform.kt
+++ b/curseforge/src/main/kotlin/net/xolt/freecam/publish/platforms/CurseForgePlatform.kt
@@ -1,5 +1,6 @@
 package net.xolt.freecam.publish.platforms
 
+import me.hypherionmc.curseupload.errors.InvalidCurseVersionException
 import net.xolt.freecam.model.ReleaseMetadata
 import net.xolt.freecam.publish.logging.Logger
 import net.xolt.freecam.publish.model.CurseForgeConfig
@@ -32,8 +33,16 @@ internal class DefaultCurseForgePlatform(
 
     override suspend fun publishRelease(metadata: ReleaseMetadata, artifacts: List<ReleaseArtifact>) {
         artifacts.forEach { spec ->
-            logger.info { "publishing artifact ${spec.name}" }
-            client.uploadFile(spec)
+            try {
+                logger.info { "publishing artifact ${spec.name}" }
+                client.uploadFile(spec)
+            } catch (e: InvalidCurseVersionException) {
+                if (!e.isSnapshotOnly) throw e
+
+                // Workaround CurseForge's flaky snapshot version support
+                logger.warn { "retrying ${spec.name} without invalid snapshot versions: ${e.invalidVersions}" }
+                client.uploadFile(spec, excludeVersions = e.invalidVersions.toSet())
+            }
         }
     }
 }

--- a/curseforge/src/test/kotlin/net/xolt/freecam/publish/platforms/DefaultCurseForgePlatformTest.kt
+++ b/curseforge/src/test/kotlin/net/xolt/freecam/publish/platforms/DefaultCurseForgePlatformTest.kt
@@ -1,0 +1,128 @@
+package net.xolt.freecam.publish.platforms
+
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import me.hypherionmc.curseupload.errors.InvalidCurseVersionException
+import net.xolt.freecam.model.ReleaseMetadata
+import net.xolt.freecam.publish.logging.TestLogger
+import net.xolt.freecam.publish.model.CurseForgeConfig
+import net.xolt.freecam.publish.model.ReleaseArtifact
+import net.xolt.freecam.test.ReleaseArtifactFixtures.testArtifact
+import kotlin.test.Test
+
+class DefaultCurseForgePlatformTest {
+
+    private fun createInvalidCurseVersionException(
+        invalidVersions: Collection<String> = emptyList(),
+        validVersions: Collection<String> = emptyList(),
+    ) = InvalidCurseVersionException.of(invalidVersions, validVersions)
+
+    @Test
+    fun `retries upload when all invalid versions are snapshots`() = runTest {
+        val artifact = testArtifact()
+
+        val invalidVersions = setOf("1.21-snapshot", "26.1-snapshot")
+
+        val exception = createInvalidCurseVersionException(invalidVersions = invalidVersions)
+
+        val client = mockk<CurseForgeClient> {
+            coEvery { uploadFile(any(), excludeVersions = emptySet()) } throws exception
+            coEvery { uploadFile(any(), excludeVersions = invalidVersions) } just runs
+        }
+
+        val platform = DefaultCurseForgePlatform(
+            dryRun = false,
+            config = mockk<CurseForgeConfig>(),
+            logger = TestLogger(),
+            client = client,
+        )
+
+        platform.publishRelease(
+            metadata = mockk<ReleaseMetadata>(),
+            artifacts = listOf(artifact),
+        )
+
+        coVerify(exactly = 1) {
+            client.uploadFile(artifact, excludeVersions = emptySet())
+        }
+
+        coVerify(exactly = 1) {
+            client.uploadFile(artifact, excludeVersions = invalidVersions)
+        }
+    }
+
+    @Test
+    fun `does not retry upload when any invalid version is not a snapshot`() = runTest {
+        val artifact = testArtifact()
+
+        val invalidVersions = setOf("1.21.10", "26.1-snapshot")
+
+        val exception = createInvalidCurseVersionException(invalidVersions = invalidVersions)
+
+        val client = mockk<CurseForgeClient> {
+            coEvery { uploadFile(any(), excludeVersions = emptySet()) } throws exception
+        }
+
+        val platform = DefaultCurseForgePlatform(
+            dryRun = false,
+            config = mockk<CurseForgeConfig>(),
+            logger = TestLogger(),
+            client = client,
+        )
+
+        val ex = shouldThrowExactly<InvalidCurseVersionException> {
+            platform.publishRelease(
+                metadata = mockk<ReleaseMetadata>(),
+                artifacts = listOf(artifact),
+            )
+        }
+
+        ex shouldBeSameInstanceAs exception
+
+        coVerify(exactly = 1) {
+            client.uploadFile(artifact, excludeVersions = emptySet())
+        }
+
+        coVerify(exactly = 0) {
+            client.uploadFile(artifact, excludeVersions = invalidVersions)
+        }
+    }
+
+    @Test
+    fun `does not retry when retry also fails`() = runTest {
+        val artifact = testArtifact()
+
+        val invalidVersions = setOf("1.21.10-snapshot", "26.1-snapshot")
+        val exception = createInvalidCurseVersionException(invalidVersions = invalidVersions)
+
+        val client = mockk<CurseForgeClient> {
+            coEvery { uploadFile(any<ReleaseArtifact>(), excludeVersions = any<Set<String>>()) } throws exception
+        }
+
+        val platform = DefaultCurseForgePlatform(
+            dryRun = false,
+            config = mockk<CurseForgeConfig>(),
+            logger = TestLogger(),
+            client = client,
+        )
+
+        val ex = shouldThrowExactly<InvalidCurseVersionException> {
+            platform.publishRelease(
+                metadata = mockk<ReleaseMetadata>(),
+                artifacts = listOf(artifact),
+            )
+        }
+
+        ex shouldBeSameInstanceAs exception
+
+        coVerify(exactly = 1) {
+            client.uploadFile(artifact, excludeVersions = emptySet())
+        }
+
+        coVerify(exactly = 1) {
+            client.uploadFile(artifact, excludeVersions = invalidVersions)
+        }
+    }
+}

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -7,7 +7,7 @@ coroutines = "1.10.2"
 clikt = "5.1.0"
 kotest = "6.1.2"
 mockk = "1.14.9"
-curse4j = "1.1.0"
+curse4j = "1.1.1"
 modrinth4j = "da95ff1ea9130d1d0729ac58b58f758170a7abc0" # 2024-01-05
 
 [libraries]


### PR DESCRIPTION
CurseForge has flaky support for snapshot versions. Retry if all "invalid" versions are snapshot versions.

See https://github.com/firstdarkdev/CurseUpload4J/issues/3